### PR TITLE
Fix three code bugs

### DIFF
--- a/pkg/toolsets/toolsets.go
+++ b/pkg/toolsets/toolsets.go
@@ -152,9 +152,13 @@ func (t *Toolset) SetReadOnly() {
 func (t *Toolset) AddWriteTools(tools ...server.ServerTool) *Toolset {
 	// Silently ignore if the toolset is read-only to avoid any breach of that contract
 	for _, tool := range tools {
-		if *tool.Tool.Annotations.ReadOnlyHint {
-			panic(fmt.Sprintf("tool (%s) is incorrectly annotated as read-only", tool.Tool.Name))
-		}
+        // Guard against nil annotations or hints to avoid panics.
+        // We only block if the tool is explicitly annotated as read-only.
+        if tool.Tool.Annotations != nil && tool.Tool.Annotations.ReadOnlyHint != nil {
+            if *tool.Tool.Annotations.ReadOnlyHint {
+                panic(fmt.Sprintf("tool (%s) is incorrectly annotated as read-only", tool.Tool.Name))
+            }
+        }
 	}
 	if !t.readOnly {
 		t.writeTools = append(t.writeTools, tools...)
@@ -164,9 +168,10 @@ func (t *Toolset) AddWriteTools(tools ...server.ServerTool) *Toolset {
 
 func (t *Toolset) AddReadTools(tools ...server.ServerTool) *Toolset {
 	for _, tool := range tools {
-		if !*tool.Tool.Annotations.ReadOnlyHint {
-			panic(fmt.Sprintf("tool (%s) must be annotated as read-only", tool.Tool.Name))
-		}
+        // Read tools must be explicitly annotated as read-only. Treat missing/ nil as invalid.
+        if tool.Tool.Annotations == nil || tool.Tool.Annotations.ReadOnlyHint == nil || !*tool.Tool.Annotations.ReadOnlyHint {
+            panic(fmt.Sprintf("tool (%s) must be annotated as read-only", tool.Tool.Name))
+        }
 	}
 	t.readTools = append(t.readTools, tools...)
 	return t


### PR DESCRIPTION
<!--
    Thank you for contributing to GitHub MCP Server!
    Please reference an existing issue: `Closes #NUMBER`

    Screenshots or videos of changed behavior is incredibly helpful and always appreciated.
    Consider addressing the following:
    - Tradeoffs: List tradeoffs you made to take on or pay down tech debt.
    - Alternatives: Describe alternative approaches you considered and why you discarded them.
-->

Closes:

This PR addresses three bugs to improve robustness and reliability:

1.  **Fix nil-pointer panic in `pkg/toolsets/toolsets.go`**:
    *   **Why**: Previously, adding tools without `Annotations` or with a nil `ReadOnlyHint` could cause a panic due to unsafe dereferencing.
    *   **What**: Added nil checks for `Annotations` and `ReadOnlyHint` in `AddWriteTools` and `AddReadTools`. `AddWriteTools` now only panics if a tool is *explicitly* annotated as read-only, while `AddReadTools` requires tools to be *explicitly* read-only.

2.  **Ensure environment variable overrides in `pkg/translations/translations.go`**:
    *   **Why**: The `TranslationHelper` was not reliably reading `GITHUB_MCP_*` environment variables, leading to inconsistent overrides. Manual `os.LookupEnv` bypassed Viper's precedence.
    *   **What**: Configured Viper with `AutomaticEnv`, `SetEnvPrefix("GITHUB_MCP")`, and `SetEnvKeyReplacer` to correctly handle `GITHUB_MCP_`-prefixed environment variables and normalize keys consistently.

3.  **Improve CLI pretty-printer robustness in `cmd/mcpcurl/main.go`**:
    *   **Why**: The `mcpcurl` pretty-printer would fail or return nothing when encountering non-JSON text or malformed JSON in responses.
    *   **What**: Modified `printResponse` to gracefully handle text content. It now attempts to parse as a JSON object, then a JSON array, and falls back to printing raw text if neither succeeds. It also ensures the original response is printed if no printable text content is found.

**Tradeoffs**: None. These changes are direct bug fixes that improve stability and expected behavior without introducing new complexities or regressions.
**Alternatives**: None considered, as the current fixes directly address the identified issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-a0c4ed0e-cc63-4410-8fd4-c63f0f7fddc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a0c4ed0e-cc63-4410-8fd4-c63f0f7fddc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

